### PR TITLE
Added ProverStateManager printout(info) to worker

### DIFF
--- a/zero_bin/worker/src/main.rs
+++ b/zero_bin/worker/src/main.rs
@@ -38,9 +38,11 @@ async fn main() -> Result<()> {
 
     let args = Cli::parse();
 
-    args.prover_state_config
-        .into_prover_state_manager()
-        .initialize()?;
+    let psm = args.prover_state_config.into_prover_state_manager();
+
+    info!("Worker ProverStateManager: {:?}", psm);
+    
+    psm.initialize()?;
 
     let runtime = WorkerRuntime::from_config(&args.paladin, register()).await?;
     //const IPC_ROUTING_KEY: Uuid = Uuid::max(); // copied over from paladin-core's

--- a/zero_bin/worker/src/main.rs
+++ b/zero_bin/worker/src/main.rs
@@ -38,6 +38,8 @@ async fn main() -> Result<()> {
 
     let args = Cli::parse();
 
+    info!("Worker CLI: {:?}", args);
+
     let psm = args.prover_state_config.into_prover_state_manager();
 
     info!("Worker ProverStateManager: {:?}", psm);


### PR DESCRIPTION
Should enable us to see what circuits and some other settings the workers are pulling from the environment